### PR TITLE
save contents of editor to textarea on change event

### DIFF
--- a/lib/client/ghostdown.js
+++ b/lib/client/ghostdown.js
@@ -42,6 +42,7 @@ Template.GhostEditor.rendered = function() {
 
                 editor.on("change", function() {
                     updatePreview();
+                    editor.save();
                 });
 
                 updatePreview();


### PR DESCRIPTION
I found an easy solution to #3, on the change event we can just save the contents of the editor to the (hidden) textarea where it can easily retrieved.

Will you pull this in or is there another way I did not see?
