### PR TITLE
Now shows "1 word" instead of "1 words"

### DIFF
--- a/lib/client/ghostdown.js
+++ b/lib/client/ghostdown.js
@@ -36,6 +36,8 @@ Template.GhostEditor.rendered = function() {
 
         if (editorValue.length) {
           var count = editorValue.match(/\S+/g).length;
+          if(count===1){wordCount.innerHtml = 1 + "word";}
+        
           wordCount.innerHTML = count + ' words';
           Session.set('editor-word-count', count);
         }


### PR DESCRIPTION
The code before this commit shows 1 words if there is one word, but technically, it should be 1 word. I changed that.
